### PR TITLE
Request user details on Welcome page load

### DIFF
--- a/web/src/pages/landing/Landing.test.tsx
+++ b/web/src/pages/landing/Landing.test.tsx
@@ -74,9 +74,7 @@ test("button click requests user data", async () => {
     expect(getSpy).toHaveBeenCalledWith(serverMeEndpoint, {
       withCredentials: true,
     });
-    expect(history.replace).toHaveBeenCalledWith("/welcome", {
-      user: testUser,
-    });
+    expect(history.replace).toHaveBeenCalledWith("/welcome");
   });
 });
 

--- a/web/src/pages/landing/Landing.tsx
+++ b/web/src/pages/landing/Landing.tsx
@@ -20,7 +20,7 @@ function Landing() {
         if (result.error) {
           return Promise.reject(result.error);
         }
-        history.replace("/welcome", { user: result.data });
+        history.replace("/welcome");
       })
       .catch((e: AxiosError) => {
         if (e.response?.status === 401) {

--- a/web/src/pages/welcome/Welcome.tsx
+++ b/web/src/pages/welcome/Welcome.tsx
@@ -1,31 +1,41 @@
-import { Box, Heading, Text, VStack } from "@chakra-ui/react";
+import { Box, Heading, Spinner, Text, VStack } from "@chakra-ui/react";
+import { AxiosError } from "axios";
 import { useHistory } from "react-router-dom";
 
 import "./Welcome.css";
+import { useUser } from "../../hooks/use-user";
+import { QueryObserverResult } from "react-query";
 import { User } from "../../data/user";
 
 function Welcome() {
   const history = useHistory();
-  const state = history.location.state as WelcomeState;
+  const user = useUser();
 
-  if (!state?.user) {
-    history.replace("/");
-    return <></>;
+  if (!user.data) {
+    user.refetch().then((result: QueryObserverResult<User, AxiosError>) => {
+      if (result.error) {
+        history.replace("/");
+      }
+    });
+  }
+
+  if (user.isLoading || !user.data) {
+    return (
+      <VStack spacing="24px">
+        <Spinner data-testid="spinner" marginTop={"50px"} />
+      </VStack>
+    );
   }
 
   return (
     <VStack spacing="24px">
       <Heading>Welcome</Heading>
       <Box alignContent="left" width="50%">
-        <Text>Org id: {state.user.organizationUuid}</Text>
-        <Text>Display name: {state.user.displayName}</Text>
+        <Text>Org id: {user.data.organizationUuid}</Text>
+        <Text>Display name: {user.data.displayName}</Text>
       </Box>
     </VStack>
   );
-}
-
-interface WelcomeState {
-  user: User;
 }
 
 export default Welcome;


### PR DESCRIPTION
Previously the page would require state params to be passed from the landing page, otherwise it would redirect back to it. The OAuth flow now returns the user to the Welcome screen after login, so it should make its own request for user info.

The flows are now as follows:

Landing screen (on button click):
- If the request for /v1/me succeeds then redirect to the Welcome screen
- If the request returns a 401 status then begin the OAuth flow

Welcome screen:
- If there is user data from the landing screen, show it. Otherwise request the `/v1/me` endpoint
- If request succeeds then show the user info
- On error redirect to Landing