### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
       timezone: "Europe/Stockholm"
     labels:
       - "Lights On"
-      - "dependencies"
+      - "Dependencies"
     reviewers:
       - "iZettle/partner-growth"
 
@@ -23,7 +23,7 @@ updates:
       timezone: "Europe/Stockholm"
     labels:
       - "Lights On"
-      - "dependencies"
+      - "Dependencies"
     reviewers:
       - "iZettle/partner-growth"
 
@@ -36,7 +36,7 @@ updates:
       timezone: "Europe/Stockholm"
     labels:
       - "Lights On"
-      - "dependencies"
+      - "Dependencies"
     reviewers:
       - "iZettle/partner-growth"
 
@@ -49,6 +49,6 @@ updates:
       timezone: "Europe/Stockholm"
     labels:
       - "Lights On"
-      - "dependencies"
+      - "Dependencies"
     reviewers:
       - "iZettle/partner-growth"


### PR DESCRIPTION
### What
Add dependabot to repo. 

### Why
To automate dependency updates. 

### How
Add `.github/dependabot.yml`. 

Note that`docker` appears twice because there are two `Dockerfiles` in different directories (apparently that's still [the workaround](https://github.com/dependabot/dependabot-core/issues/2824)). 

---

JIRA: [MSEU-3074](https://izettle.atlassian.net/browse/MSEU-3074)