### PR TITLE
Change kotlin plugin dependency versions so they match

### DIFF
--- a/server/app/build.gradle.kts
+++ b/server/app/build.gradle.kts
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.5.21"
+    kotlin("jvm") version "1.5.31"
     kotlin("plugin.serialization") version "1.5.31"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
     id("com.github.johnrengelman.shadow") version "7.1.0"


### PR DESCRIPTION
### What
Fixed the server's `build.gradle.kts`. 

### Why
After a dependabot change, the server doesn't build. 

(Note there's a larger issue here, in that we've now got dependabot set up to create PRs, but no automated build status check to make sure they actually work. Planning to address this in another PR, likely by adding a script – this is just to put the immediate problem right.) 

### How
Correct plugin Kotlin versions by making sure they match. 

JIRA: [MSEU-3074](https://izettle.atlassian.net/browse/MSEU-3074)