### PR TITLE
Add supported regions section to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Zettle Example Integration
 
+- [Supported regions](#supported-regions)
 - [Introduction](#introduction) 
   - [Structure](#structure)
 - [Prerequisites](#prerequisites)
@@ -8,6 +9,27 @@
   - [Step 2: Running via Docker](#step-2-running-via-docker)
 - [Subprojects](#subprojects)
 - [Certificates](#certificates)
+
+## Supported regions
+
+Zettle provides APIs for you to integrate Zettle Go with your services.
+
+> **Note:** The API documentation is currently in the beta phase.
+
+Currently, Zettle provides APIs for the following markets:
+
+-   United Kingdom
+-   Sweden
+-   Brazil
+-   Norway
+-   Denmark
+-   Finland
+-   Germany
+-   Mexico
+-   Netherlands
+-   France
+-   Spain
+-   Italy
 
 ## Introduction
 


### PR DESCRIPTION
https://izettle.atlassian.net/browse/MSEU-3099

**What**
An update to the Example integration README to specify which regions our APIs are supported in

**Why** 
To mitigate the risk of developers outwith these regions finding our APIs, not realising that our public API offering is a work in progress and having a poor developer experience as a result (case in point - we don't market our API offering in the US).

**How**
Duplicate the text used within out API docs (hosted on Github) specifying which regions our APIs are intended for. 
see https://github.com/iZettle/api-documentation