### PR TITLE
changed url builder in ZettleUserFetcher and in ZettleUserFetcherTests

### DIFF
--- a/server/app/src/main/kotlin/server/client/zettle/user/ZettleUserFetcher.kt
+++ b/server/app/src/main/kotlin/server/client/zettle/user/ZettleUserFetcher.kt
@@ -17,7 +17,7 @@ class ZettleUserFetcher(
 
     override suspend fun fetchMe(accessToken: String): Result<ZettleUserResponse> {
         val url = baseUrl.newBuilder()
-            .addPathSegments("users/me")
+            .addPathSegments("users/self")
             .build()
         val request = Request.Builder()
             .get()

--- a/server/app/src/test/kotlin/server/client/zettle/user/ZettleUserFetcherTests.kt
+++ b/server/app/src/test/kotlin/server/client/zettle/user/ZettleUserFetcherTests.kt
@@ -38,7 +38,7 @@ class ZettleUserFetcherTests {
 
         val sentRequest = mockSender.spySendRequest
             ?: fail("expected a sent request")
-        val expectedUrl = "https://test.local/users/me"
+        val expectedUrl = "https://test.local/users/self"
         assertEquals(expectedUrl, sentRequest.url.toString())
         assertEquals("GET", sentRequest.method)
         assertEquals("Bearer test token", sentRequest.header(HttpHeaders.Authorization))


### PR DESCRIPTION
https://izettle.atlassian.net/browse/MSEU-3096

**What**
Changing mentions of "user/me" to "user/self" in relation to Zettle oauth endpoints

**Why**
"self" is consistent with similar funcitons in other Zettle APIs, "me" is legacy

**How**
I've only changed this in the server component and in the relevant test. So there are still references to "me" within the context of the example integration (e.g. the web component still goes to the v1/me endpoint provided by the server). But in the context of Zettle it's now "self". If we want to move from "me" style to "self" style internally within the integration we can do that in another ticket.