### PR TITLE
Install nss to integrate mkcert with Firefox

### DIFF
--- a/create-certificate.sh
+++ b/create-certificate.sh
@@ -13,6 +13,7 @@ fi
 echo "Generating new TLS certificate for localhost"
 
 brew list mkcert || (brew install mkcert && echo "mkcert will ask for permission to install a new certificate authority on your system")
+brew list nss || (brew install nss && echo "Installing nss for mkcert Firefox integration")
 mkcert -install
 mkdir -p .cert
 mkcert -key-file $KEY -cert-file $CERT "localhost"


### PR DESCRIPTION
The `nss` brew module is required for `mkcert` to work with Firefox - as noted in their documentation.

Installing it before `mkcert` generated new keys fixed initial certificate issues on my personal laptop.